### PR TITLE
[ml][mlworker&model] Add process cache and chunk-based model for PS-SSP

### DIFF
--- a/core/constants.hpp
+++ b/core/constants.hpp
@@ -73,6 +73,9 @@ constexpr const char* const kASP = "ASP";
 // worker type
 constexpr const char* const kWorkerType = "worker_type";
 constexpr const char* const kSSPWorker = "SSPWorker";
+constexpr const char* const kSSPWorkerChunk = "SSPWorkerChunk";
+constexpr const char* const kPSSharedWorker = "PSSharedWorker";
+constexpr const char* const kPSSharedWorkerChunk = "PSSharedChunkWorker";
 
 constexpr const char* const kNumWorkers = "num_workers";
 constexpr const char* const kStaleness = "staleness";

--- a/kvstore/handles/basic.hpp
+++ b/kvstore/handles/basic.hpp
@@ -86,7 +86,7 @@ void update(int kv_id, int server_id, husky::base::BinStream& bin, StorageT& sto
         }
         delete p_recv;
     } else {
-        throw husky::base::HuskyException("Unknown cmd");
+        throw husky::base::HuskyException("Unknown cmd " + std::to_string(cmd));
     }
 }
 
@@ -162,7 +162,7 @@ KVPairs<Val> retrieve(int kv_id, int server_id, husky::base::BinStream& bin, Sto
         }
         return send;
     } else {
-        throw husky::base::HuskyException("Unknown cmd");
+        throw husky::base::HuskyException("Unknown cmd " + std::to_string(cmd));
     }
 }
 

--- a/ml/mlworker/ps.hpp
+++ b/ml/mlworker/ps.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "kvstore/kvstore.hpp"
+#include "ml/model/chunk_based_ps_model.hpp"
+#include "ml/model/model.hpp"
+#include "ml/shared/shared_state.hpp"
 
 namespace ml {
 namespace mlworker {
@@ -130,7 +133,7 @@ class SSPWorker : public mlworker::GenericMLWorker {
 
         // find uncached_keys
         std::vector<husky::constants::Key> uncached_keys;
-        if (pull_count_ - cache_ts_ < staleness_ || cached_kv_.size() == 0) {
+        if (pull_count_ - cache_ts_ > staleness_ || cached_kv_.size() == 0) {
             uncached_keys = keys;
         } else {
             for (auto& key : keys) {
@@ -205,10 +208,87 @@ class SSPWorker : public mlworker::GenericMLWorker {
     std::vector<float> delta_;
 };
 
+class SSPWorkerChunk : public mlworker::GenericMLWorker {
+   public:
+    SSPWorkerChunk() = delete;
+    SSPWorkerChunk(const SSPWorkerChunk&) = delete;
+    SSPWorkerChunk operator=(const SSPWorkerChunk&) = delete;
+    SSPWorkerChunk(SSPWorkerChunk&&) = delete;
+    SSPWorkerChunk operator=(SSPWorkerChunk&&) = delete;
+
+    SSPWorkerChunk(const husky::Info& info) :
+        model_id_(static_cast<husky::MLTask*>(info.get_task())->get_kvstore()),
+        model_(model_id_, static_cast<husky::MLTask*>(info.get_task())->get_dimensions()),
+        local_id_(info.get_local_id()) {
+            // Configure model
+            model_.SetStaleness(stoi(info.get_task()->get_hint().at(husky::constants::kStaleness)));
+            // Set kvworker
+            kvworker_ = kvstore::KVStore::Get().get_kvworker(local_id_);
+    }
+
+    virtual void Push(const std::vector<husky::constants::Key>& keys, const std::vector<float>& vals) override {
+        assert(++push_count_ == pull_count_);
+        // 1. Push updates to kvstore
+        ts_ = kvworker_->Push(model_id_, keys, vals);
+
+        // 2. Update local model
+        model_.Push(keys, vals);
+    }
+
+    virtual void Pull(const std::vector<husky::constants::Key>& keys, std::vector<float>* vals) override {
+        assert(push_count_ == pull_count_);
+        ++pull_count_;
+
+        if(ts_ != -1) kvworker_->Wait(model_id_, ts_);
+
+        model_.Pull(keys, vals, local_id_);
+    }
+
+    virtual void Prepare_v2(const std::vector<husky::constants::Key>& keys) override {
+        ++pull_count_;
+        keys_ = const_cast<std::vector<husky::constants::Key>*>(&keys);
+        model_.Prepare(keys, local_id_);
+        delta_.clear();
+        delta_.resize(keys.size());
+    }
+
+    virtual float Get_v2(husky::constants::Key idx) override {
+        return model_.At(keys_->at(idx));
+    }
+    virtual void Update_v2(husky::constants::Key idx, float val) override {
+        delta_[idx] += val;
+        model_.Inc(keys_->at(idx), val);
+    }
+    virtual void Update_v2(const std::vector<float>& vals) override {
+        for (int i = 0; i < vals.size(); ++i) {
+            model_.Inc(keys_->at(i), vals[i]);
+            delta_[i] += vals[i];
+        }
+    }
+    virtual void Clock_v2() override { Push(*keys_, delta_); }
+
+
+   private:
+    int model_id_;
+    int staleness_ = 1;
+    kvstore::KVWorker* kvworker_ = nullptr;
+    int local_id_;
+
+    int push_count_ = 0;
+    int pull_count_ = 0;
+    int ts_ = -1;
+
+    model::ChunkBasedModelWithClocks model_;
+    // For v2
+    std::vector<husky::constants::Key>* keys_;
+    std::vector<float> delta_;
+};
+
 class PSSharedWorker : public mlworker::GenericMLWorker {
     struct PSState {
-        model::Model* p_model_;
+        model::ChunkBasedPSModel* p_model_;
     };
+
    public:
     PSSharedWorker() = delete;
     PSSharedWorker(const PSSharedWorker&) = delete;
@@ -221,16 +301,20 @@ class PSSharedWorker : public mlworker::GenericMLWorker {
           info_(info),
           model_id_(static_cast<husky::MLTask*>(info.get_task())->get_kvstore()) {
         size_t num_params = static_cast<husky::MLTask*>(info_.get_task())->get_dimensions();
-        if (info_.get_local_tids().at(0) == info_.get_global_id()) {
+        if (info.is_leader()) {
             PSState* state = new PSState;
-            // TODO!!! which ChunkBasedModel?
-            state->p_model_ = (model::Model*) new model::ChunkBasedModel(model_id_, num_params);
+            state->p_model_ = new model::ChunkBasedPSModel(model_id_, num_params);
             // 1. Init
             shared_state_.Init(state);
         }
         // 2. Sync
         shared_state_.SyncState();
+        staleness_ = stoi(info.get_task()->get_hint().at(husky::constants::kStaleness));
+        // set local id and kvworker
+        local_id_ = info.get_local_id();
+        kvworker_ = kvstore::KVStore::Get().get_kvworker(local_id_);
     }
+
     ~PSSharedWorker() {
         shared_state_.Barrier();
         if (info_.get_local_tids().at(0) == info_.get_global_id()) {
@@ -238,23 +322,258 @@ class PSSharedWorker : public mlworker::GenericMLWorker {
             delete shared_state_.Get();
         }
     }
+
     virtual void Push(const std::vector<husky::constants::Key>& keys, const std::vector<float>& vals) override {
-        // 1. Update Local model
-        // 2. Push chunks to PS
+        assert(pull_count_ == push_count_ + 1);
+        ++push_count_;
+        // 1. Push updates to PS
+        ts_ = kvworker_->Push(model_id_, keys, vals);
+
+        // 2. Update local model: Aggregate
+        for (int i = 0; i < keys.size(); i++) {
+            cached_kv_.at(keys[i]) += vals[i];
+        }
     }
+
     virtual void Pull(const std::vector<husky::constants::Key>& keys, std::vector<float>* vals) override {
-        // 1. Check the staleness of local model
-        // 2. Collect those chunks that are too old
-        // 3. Check the staleness of shared model
-        // 4. Collect Those chunks that are too old
-        // 5. Pull chunks From PS, udpate shared/local model
+        assert(pull_count_ == push_count_);
+        ++pull_count_;
+        // TODO: is it necessary to wait?
+        if (ts_ != -1) kvworker_->Wait(model_id_, ts_);  // Wait for last Push
+        
+        Prepare(keys);
+
+        vals->resize(keys.size());
+        for (int i = 0; i < keys.size(); i++) {
+            vals->at(i) = cached_kv_[keys[i]];
+        }
     }
+
+    virtual void Prepare_v2(const std::vector<husky::constants::Key>& keys) override {
+        ++pull_count_;
+        keys_ = const_cast<std::vector<husky::constants::Key>*>(&keys);
+        Prepare(keys);
+        delta_.clear();
+        delta_.resize(keys.size());
+    }
+
+    virtual void Prepare(const std::vector<husky::constants::Key>& keys) {
+        std::vector<husky::constants::Key> uncached_keys;
+        // 1. Check the staleness of local model
+        if (pull_count_ - cache_ts_ > staleness_ || cached_kv_.empty()) {  // Thread-cache is too old or empty
+            cached_kv_.clear();
+            uncached_keys = keys;
+        } else {
+            // 2. Collect all missing keys
+            for (auto& key : keys) {
+                if (cached_kv_.find(key) == cached_kv_.end()) uncached_keys.push_back(key);
+            }
+        }
+
+        // 3. Pull missing keys from process cache
+        if (!uncached_keys.empty()) {
+            std::vector<float> tmp_vals;
+            int stale = std::max(pull_count_ - staleness_, 0);
+            auto cache_ts = shared_state_.Get()->p_model_->PullWithMinClock(uncached_keys, &tmp_vals, local_id_, stale);
+            if (keys.size() == uncached_keys.size()) {
+                cache_ts_ = cache_ts;
+            }
+            for (int i = 0; i < uncached_keys.size(); ++i) {
+                cached_kv_[uncached_keys[i]] = tmp_vals[i];
+            }
+        }
+    }
+
+    virtual float Get_v2(husky::constants::Key idx) override { return cached_kv_[keys_->at(idx)]; }
+    virtual void Update_v2(husky::constants::Key idx, float val) override {
+        delta_[idx] += val;
+        cached_kv_[keys_->at(idx)] += val;
+    }
+    virtual void Update_v2(const std::vector<float>& vals) override {
+        for (int i = 0; i < vals.size(); ++i) {
+            cached_kv_[keys_->at(i)] += vals[i];
+            delta_[i] += vals[i];
+        }
+    }
+    virtual void Clock_v2() override {
+        Push(*keys_, delta_);
+    }
+
    private: 
     int model_id_;
     const husky::Info& info_;
+    int local_id_;
+    kvstore::KVWorker* kvworker_ = nullptr;
     // Shared Model
     SharedState<PSState> shared_state_;
     // Local Model
+    std::unordered_map<husky::constants::Key, float> cached_kv_;  // key_val dictionary
+    int cache_ts_;
+    int ts_ = -1;
+    
+    // Progress
+    int pull_count_ = 0;  // clock
+    int push_count_ = 0;
+    int staleness_ = 1;  // default is synchronouse
+
+    // For v2
+    std::vector<husky::constants::Key>* keys_;
+    std::vector<float> delta_;
+};
+
+class PSSharedChunkWorker : public mlworker::GenericMLWorker {
+    struct PSState {
+        model::ChunkBasedPSModel* p_model_;
+    };
+
+   public:
+    PSSharedChunkWorker() = delete;
+    PSSharedChunkWorker(const PSSharedChunkWorker&) = delete;
+    PSSharedChunkWorker& operator=(const PSSharedChunkWorker&) = delete;
+    PSSharedChunkWorker(PSSharedChunkWorker&&) = delete;
+    PSSharedChunkWorker& operator=(PSSharedChunkWorker&&) = delete;
+
+    PSSharedChunkWorker(const husky::Info& info, zmq::context_t& context)
+        : shared_state_(info.get_task_id(), info.is_leader(), info.get_num_local_workers(), context),
+          info_(info),
+          model_id_(static_cast<husky::MLTask*>(info.get_task())->get_kvstore()),
+          chunk_clocks_(kvstore::RangeManager::Get().GetChunkNum(model_id_), -1),
+          params_(kvstore::RangeManager::Get().GetChunkNum(model_id_)) {
+        size_t num_params = static_cast<husky::MLTask*>(info_.get_task())->get_dimensions();
+        if (info.is_leader()) {
+            PSState* state = new PSState;
+            state->p_model_ = new model::ChunkBasedPSModel(model_id_, num_params);
+            // 1. Init
+            shared_state_.Init(state);
+        }
+        // 2. Sync
+        shared_state_.SyncState();
+        staleness_ = stoi(info.get_task()->get_hint().at(husky::constants::kStaleness));
+
+        // Set local id and kvworker
+        local_id_ = info.get_local_id();
+        kvworker_ = kvstore::KVStore::Get().get_kvworker(local_id_);
+    }
+
+    ~PSSharedChunkWorker() {
+        shared_state_.Barrier();
+        if (info_.get_local_tids().at(0) == info_.get_global_id()) {
+            delete shared_state_.Get()->p_model_;
+            delete shared_state_.Get();
+        }
+    }
+
+    virtual void Push(const std::vector<husky::constants::Key>& keys, const std::vector<float>& vals) override {
+        assert(pull_count_ == push_count_ + 1);
+        ++push_count_;
+        // 1. Push updates to PS
+        ts_ = kvworker_->Push(model_id_, keys, vals);
+
+        // 2. Update local model: Aggregate
+        auto& range_manager = kvstore::RangeManager::Get();
+        for (int i = 0; i < keys.size(); ++i) {
+            auto loc = range_manager.GetLocation(model_id_, keys[i]);
+            params_[loc.first][loc.second] += vals[i];
+        }
+    }
+
+    virtual void Pull(const std::vector<husky::constants::Key>& keys, std::vector<float>* vals) override {
+        assert(pull_count_ == push_count_);
+        ++pull_count_;
+        // TODO: is it necessary to wait?
+        if (ts_ != -1) kvworker_->Wait(model_id_, ts_);  // Wait for last Push
+        
+        Prepare(keys);
+
+        vals->resize(keys.size());
+        auto& range_manager = kvstore::RangeManager::Get();
+        for (int i = 0; i < keys.size(); i++) {
+            auto loc = range_manager.GetLocation(model_id_, keys[i]);
+            vals->at(i) = params_[loc.first][loc.second];
+        }
+    }
+
+    virtual void Prepare_v2(const std::vector<husky::constants::Key>& keys) override {
+        ++pull_count_;
+        keys_ = const_cast<std::vector<husky::constants::Key>*>(&keys);
+        Prepare(keys);
+        delta_.clear();
+        delta_.resize(keys.size());
+    }
+
+    virtual void Prepare(const std::vector<husky::constants::Key>& keys) {
+        auto& range_manager = kvstore::RangeManager::Get();
+        std::vector<size_t> uncached_chunks;
+        int min_clock = std::max(0, pull_count_ - staleness_);
+
+        // 1. Check the staleness of local model
+        size_t current_chunk_id;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto chunk_id = range_manager.GetLocation(model_id_, keys[i]).first;
+            if ((i == 0 || chunk_id != current_chunk_id) && chunk_clocks_[chunk_id] < min_clock) {
+                // 2. Collect all missing chunks
+                uncached_chunks.push_back(chunk_id);
+            }
+            current_chunk_id = chunk_id;
+        }
+
+        // 3. Pull missing chunks from process cache
+        if (!uncached_chunks.empty()) {
+            std::vector<std::vector<float>*> chunk_ptrs;
+            chunk_ptrs.reserve(uncached_chunks.size());
+            for (auto chunk_id : uncached_chunks) {
+                chunk_ptrs.push_back(&params_[chunk_id]);
+            }
+            shared_state_.Get()->p_model_->PullChunksWithMinClock(uncached_chunks, chunk_ptrs, chunk_clocks_, local_id_, min_clock);
+        }
+    }
+
+    virtual float Get_v2(husky::constants::Key idx) override {
+        auto& range_manager = kvstore::RangeManager::Get();
+        auto loc = range_manager.GetLocation(model_id_, keys_->at(idx));
+        return params_[loc.first][loc.second];
+    }
+
+    virtual void Update_v2(husky::constants::Key idx, float val) override {
+        delta_[idx] += val;
+        auto& range_manager = kvstore::RangeManager::Get();
+        auto loc = range_manager.GetLocation(model_id_, keys_->at(idx));
+        params_[loc.first][loc.second] += val;
+    }
+
+    virtual void Update_v2(const std::vector<float>& vals) override {
+        auto& range_manager = kvstore::RangeManager::Get();
+        for (int i = 0; i < vals.size(); ++i) {
+            auto loc = range_manager.GetLocation(model_id_, keys_->at(i));
+            params_[loc.first][loc.second] += vals[i];
+            delta_[i] += vals[i];
+        }
+    }
+
+    virtual void Clock_v2() override {
+        Push(*keys_, delta_);
+    }
+
+   private: 
+    int model_id_;
+    const husky::Info& info_;
+    int local_id_;
+    kvstore::KVWorker* kvworker_ = nullptr;
+    // Shared Model
+    SharedState<PSState> shared_state_;
+    // Local Model
+    std::vector<std::vector<float>> params_;
+    std::vector<int> chunk_clocks_;
+    int ts_ = -1;
+    
+    // Progress
+    int pull_count_ = 0;  // clock
+    int push_count_ = 0;
+    int staleness_ = 1;  // default is synchronouse
+
+    // For v2
+    std::vector<husky::constants::Key>* keys_;
+    std::vector<float> delta_;
 };
 
 }  // namespace mlworker

--- a/ml/mlworker/ps_ml_unittest.cpp
+++ b/ml/mlworker/ps_ml_unittest.cpp
@@ -1,0 +1,217 @@
+#include "gtest/gtest.h"
+
+#include "ml/mlworker/ps.hpp"
+
+#include "boost/thread.hpp"
+#include "core/instance.hpp"
+#include "core/info.hpp"
+#include "core/utility.hpp"
+
+namespace husky {
+namespace {
+
+/*
+ * Test different features:
+ * PSSharedChunkWorker: process_cache, chunk-based
+ * PSSharedWorker:      process_cache
+ * SSPWorkerChunk:      chunk-based
+ * SSPWorker
+ */
+class TestPS: public testing::Test {
+   public:
+    TestPS() {}
+    ~TestPS() {}
+
+   protected:
+    void SetUp() {
+        zmq_context = new zmq::context_t;
+        worker_info = new WorkerInfo;
+        // 1. Create WorkerInfo
+        worker_info->add_worker(0,0,0);
+        worker_info->add_worker(0,1,1);
+        worker_info->set_process_id(0);
+
+        // 2. Create Mailbox
+        el = new MailboxEventLoop(zmq_context);
+        el->set_process_id(0);
+        recver = new CentralRecver(zmq_context, "inproc://test");
+        // 3. Start KVStore
+        kvstore::KVStore::Get().Start(*worker_info, el, zmq_context);
+    }
+
+    void TearDown() {
+        kvstore::KVStore::Get().Stop();
+        delete worker_info;
+        delete el;
+        delete recver;
+        delete zmq_context;
+    }
+
+   public:
+    int num_params = 100;
+    WorkerInfo* worker_info;
+    zmq::context_t* zmq_context;
+    MailboxEventLoop* el;
+    CentralRecver * recver;
+};
+
+TEST_F(TestPS, Construct) {
+    std::map<std::string, std::string> hint = {
+        {husky::constants::kParamType, husky::constants::kChunkType},
+        {husky::constants::kConsistency, husky::constants::kSSP},
+        {husky::constants::kType, husky::constants::kPS},
+        {husky::constants::kNumWorkers, "2"},
+        {husky::constants::kStaleness, "2"}
+    };
+    int kv1 = kvstore::KVStore::Get().CreateKVStore<float>(hint, num_params, 2);
+    // Create a task
+    husky::MLTask task(0);
+    task.set_total_epoch(1);
+    task.set_dimensions(num_params);
+    task.set_kvstore(kv1);
+    task.set_hint(hint);
+    // Create an Instance
+    husky::Instance instance;
+    instance.add_thread(0, 0, 0);  // pid, tid, cid
+    instance.set_task(task);
+    // Create an Info
+    husky::Info info = husky::utility::instance_to_info(instance, *worker_info, {0, 0}, true);
+    // Create PSSharedChunkWorker
+    ml::mlworker::PSSharedChunkWorker worker1(info, *zmq_context);
+    /*
+    // Create PSSharedWorker
+    ml::mlworker::PSSharedWorker worker2(info, *zmq_context);
+    */
+    // Create SSPWorkerChunk
+    ml::mlworker::SSPWorkerChunk worker3(info);
+    // Create SSPWorker
+    ml::mlworker::SSPWorker worker4(info);
+}
+
+void testPushPull(ml::mlworker::GenericMLWorker* worker) {
+    // PushPull
+    std::vector<husky::constants::Key> keys = {0,10,20,30,40,50,60,70,80,90};
+    std::vector<float> old_vals;
+    std::vector<float> vals(keys.size(), 0.1);
+    worker->Pull(keys, &old_vals);
+    worker->Push(keys, vals);
+}
+
+void testV2(ml::mlworker::GenericMLWorker* worker) {
+    // v2 APIs
+    std::vector<husky::constants::Key> keys = {0,10,20,30,40,50,60,70,80,90};
+    worker->Prepare_v2(keys);
+    std::vector<float> old_vals;
+    std::vector<float> vals(keys.size(), 0.1);
+    for (int i = 0; i < keys.size(); ++ i)
+        old_vals.push_back(worker->Get_v2(i));
+    for (int i = 0; i < keys.size(); ++ i)
+        worker->Update_v2(i, vals[i]);
+    worker->Clock_v2();
+}
+
+void test_multiple_threads(TestPS* obj, int type) {
+    std::map<std::string, std::string> hint = {
+        {husky::constants::kParamType, husky::constants::kChunkType},
+        {husky::constants::kConsistency, husky::constants::kSSP},
+        {husky::constants::kType, husky::constants::kPS},
+        {husky::constants::kNumWorkers, "2"},
+        {husky::constants::kStaleness, "2"}
+    };
+    int kv1 = kvstore::KVStore::Get().CreateKVStore<float>(hint, 100, 2);
+    // Create a task
+    husky::MLTask task(0);
+    task.set_total_epoch(2);
+    task.set_dimensions(100);
+    task.set_kvstore(kv1);
+    task.set_hint(hint);
+    // Create an Instance
+    husky::Instance instance;
+    instance.add_thread(0, 0, 0);  // pid, tid, cid
+    instance.add_thread(0, 1, 1);  // pid, tid, cid
+    instance.set_task(task);
+
+    int iters = 10;
+
+    boost::thread t1([&instance, &obj, &iters, &type](){
+        husky::Info info = husky::utility::instance_to_info(instance, *obj->worker_info, {0, 0}, true);
+        if (type == 3) {
+            ml::mlworker::PSSharedChunkWorker worker(info, *obj->zmq_context);
+            for (int i = 0; i < iters; ++i) {
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        } else if (type == 2) {
+            ml::mlworker::PSSharedWorker worker(info, *obj->zmq_context);
+            for (int i = 0; i < iters; ++i) {
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        } else if (type == 1) {
+            ml::mlworker::SSPWorkerChunk worker(info);
+            for (int i = 0; i < iters; ++i) {
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        } else if (type == 0) {
+            ml::mlworker::SSPWorker worker(info);
+            for (int i = 0; i < iters; ++i) {
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        }
+    });
+    boost::thread t2([&instance, &obj, &iters, &type](){
+        husky::Info info = husky::utility::instance_to_info(instance, *obj->worker_info, {1, 1}, false);
+        if (type == 3) {
+            ml::mlworker::PSSharedChunkWorker worker(info, *obj->zmq_context);
+            for (int i = 0; i < iters; ++i) {
+                if (i % 3 == 0) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        } else if (type == 2) {
+            ml::mlworker::PSSharedWorker worker(info, *obj->zmq_context);
+            for (int i = 0; i < iters; ++i) {
+                if (i % 3 == 0) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        } else if (type == 1) {
+            ml::mlworker::SSPWorkerChunk worker(info);
+            for (int i = 0; i < iters; ++i) {
+                if (i % 3 == 0) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        } else if (type == 0) {
+            ml::mlworker::SSPWorker worker(info);
+            for (int i = 0; i < iters; ++i) {
+                if (i % 3 == 0) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                testPushPull(&worker);
+                testV2(&worker);
+            }
+        }
+    });
+    t1.join();
+    t2.join();
+}
+
+TEST_F(TestPS, PSSharedChunkWorker) {
+    test_multiple_threads(static_cast<TestPS*>(this), 3);
+}
+
+TEST_F(TestPS, PSSharedWorker) {
+    test_multiple_threads(static_cast<TestPS*>(this), 2);
+}
+
+TEST_F(TestPS, SSPWorkerChunk) {
+    test_multiple_threads(static_cast<TestPS*>(this), 1);
+}
+
+TEST_F(TestPS, SSPWorker) {
+    test_multiple_threads(static_cast<TestPS*>(this), 0);
+}
+
+}  // namespace
+}  // namespace husky

--- a/ml/model/chunk_based_ps_model.hpp
+++ b/ml/model/chunk_based_ps_model.hpp
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <vector>
+
+#include "boost/iterator/indirect_iterator.hpp"
+#include "boost/thread/mutex.hpp"
+#include "boost/thread/locks.hpp"
+#include "core/constants.hpp"
+#include "kvstore/kvstore.hpp"
+#include "ml/model/chunk_based_model.hpp"
+
+namespace ml {
+namespace model {
+
+class ChunkBasedPSModel {
+   public:
+    ChunkBasedPSModel(int model_id, int num_params):
+        model_id_(model_id), num_params_(num_params),
+        num_chunks_(kvstore::RangeManager::Get().GetChunkNum(model_id)),
+        params_(num_chunks_), chunk_clocks_(num_chunks_, -1), mtx_(num_chunks_) {}
+
+    virtual int PullWithMinClock(const std::vector<husky::constants::Key>& keys, std::vector<float>* vals, int local_id, int min_clock) {
+        // Prepare the keys
+        Prepare(keys, local_id, min_clock);
+
+        int clock = 0;
+        vals->resize(keys.size());
+
+        auto& range_manager = kvstore::RangeManager::Get();
+        size_t current_chunk_id;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto loc = range_manager.GetLocation(model_id_, keys[i]);
+            auto chunk_id = loc.first;
+            if (i == 0 || chunk_id != current_chunk_id) {
+                if (i != 0) mtx_[current_chunk_id].unlock();  // unlock the current chunk
+                mtx_[chunk_id].lock();  // lock the new chunk
+                current_chunk_id = chunk_id;
+                if (chunk_clocks_[chunk_id] < clock) clock = chunk_clocks_[chunk_id];
+            }
+            vals->at(i) = params_[chunk_id][loc.second];
+        }
+        if (keys.size() > 0) {
+            mtx_[current_chunk_id].unlock();  // unlock the last chunk
+        }
+        
+        return clock;
+    }
+
+    virtual void PullChunksWithMinClock(std::vector<size_t>& chunks, std::vector<std::vector<float>*>& chunk_ptrs, std::vector<int>& chunk_clocks, int local_id, int min_clock) {
+        // Collect chunks that are too stale
+        std::vector<size_t> chunks_to_fetch;
+        for (auto chunk_id : chunks) {
+            if (chunk_clocks_[chunk_id] < min_clock) {
+                chunks_to_fetch.push_back(chunk_id);
+            }
+        }
+
+        // Pull from kvstore
+        if (!chunks_to_fetch.empty()) {
+            fetch_chunk(chunks_to_fetch, local_id);
+        }
+
+        for (int i = 0; i < chunks.size(); ++i) {
+            mtx_[chunks[i]].lock();
+            *chunk_ptrs[i] = params_[chunks[i]];
+            chunk_clocks[chunks[i]] = chunk_clocks_[chunks[i]];
+            mtx_[chunks[i]].unlock();
+        }
+    }
+
+    virtual void Prepare(const std::vector<husky::constants::Key>& keys, int local_id, int min_clock) {
+        if (keys.empty()) return;
+        std::vector<size_t> chunks_to_fetch;
+
+        // 1. Collect all chunks that are not fresh enough
+        size_t current_chunk_id;
+        auto& range_manager = kvstore::RangeManager::Get();
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto loc = range_manager.GetLocation(model_id_, keys[i]);
+            auto chunk_id = loc.first;
+            if ((i == 0 || chunk_id != current_chunk_id)) {
+                if (chunk_clocks_[chunk_id] < min_clock) {  // the chunk is too stale
+                    chunks_to_fetch.push_back(chunk_id);
+                }
+            }
+            current_chunk_id = chunk_id;
+        }
+
+        // 2. Pull from kvstore
+        if (!chunks_to_fetch.empty()) {
+            fetch_chunk(chunks_to_fetch, local_id);
+        }
+    }
+
+   protected:
+    void fetch_chunk(const std::vector<size_t>& chunks, int local_id) {
+        int clock = 0;
+        // 1. get kvworker
+        auto* kvworker = kvstore::KVStore::Get().get_kvworker(local_id);
+
+        // 2. pull chunks
+        std::vector<std::vector<float>*> chunk_ptrs;
+        chunk_ptrs.reserve(chunks.size());
+        std::vector<std::vector<float>> tmp_chunks(chunks.size());
+        for (int i = 0; i < chunks.size(); ++i) { chunk_ptrs.push_back(&tmp_chunks[i]); }
+        auto ts = kvworker->PullChunksWithMinClock(this->model_id_, chunks, chunk_ptrs, &clock);
+        kvworker->Wait(this->model_id_, ts);
+
+        // 3. update chunk clocks
+        for (int i = 0; i < chunks.size(); ++i) {
+            auto chunk_id = chunks[i];
+            boost::lock_guard<boost::mutex> chunk_lock(mtx_[chunk_id]);
+            if (chunk_clocks_[chunk_id] < clock) {
+                chunk_clocks_[chunk_id] = clock;
+                params_[chunk_id] = std::move(tmp_chunks[i]);
+            }
+        }
+    }
+
+    int model_id_;
+    int num_params_;
+    int num_chunks_;
+    std::vector<std::vector<float>> params_;
+    std::vector<int> chunk_clocks_;
+    std::vector<boost::mutex> mtx_;
+};
+
+class ChunkBasedModelWithClocks : public ChunkBasedModel {
+   public:
+    ChunkBasedModelWithClocks(int model_id, int num_params) :
+        ChunkBasedModel(model_id, num_params),
+        chunk_clocks_(num_chunks_, -1),
+        range_manager_(&kvstore::RangeManager::Get()) {}
+
+    inline void SetStaleness(int staleness) { staleness_ = staleness; }
+
+    virtual void Push(const std::vector<husky::constants::Key>& keys, const std::vector<float>& vals) override {
+        // 1. Update local model
+        ChunkBasedModel::Push(keys, vals);
+
+        // 2. Inc clock
+        ++clock_;
+    }
+
+    virtual void Prepare(const std::vector<husky::constants::Key>& keys, int local_id) override {
+        // The keys should be in ascending order
+        std::vector<size_t> chunks_to_fetch;
+        int stalest = clock_ - staleness_;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto loc = range_manager_->GetLocation(model_id_, keys[i]);
+            if ((is_cached_[loc.first] == false || chunk_clocks_[loc.first] < stalest) && (chunks_to_fetch.empty() || loc.first != chunks_to_fetch.back())) {
+                chunks_to_fetch.push_back(loc.first);
+                is_cached_[loc.first] = true;
+            }
+        }
+        if (chunks_to_fetch.empty()) return;
+        fetch_chunk(chunks_to_fetch, local_id);
+    }
+
+
+    float At(const husky::constants::Key& idx) {
+        auto loc = range_manager_->GetLocation(model_id_, idx);
+        return params_[loc.first][loc.second];
+    }
+
+    void Inc(const husky::constants::Key& idx, const float& val) {
+        auto loc = range_manager_->GetLocation(model_id_, idx);
+        params_[loc.first][loc.second] += val;
+    }
+
+   private:
+    int fetch_chunk(const std::vector<size_t>& chunks, int local_id) override {
+        // 1. Get kvworker
+        auto* kvworker = kvstore::KVStore::Get().get_kvworker(local_id);
+
+        // 2. Pull Chunks
+        std::vector<std::vector<float>*> chunk_ptrs(chunks.size());
+        for (int i = 0; i < chunks.size(); ++i) { chunk_ptrs[i] = &params_[chunks[i]]; }
+        int clock;
+        auto ts = kvworker->PullChunksWithMinClock(model_id_, chunks, chunk_ptrs, &clock);
+        kvworker->Wait(model_id_, ts);
+
+        // 3. Update chunk clocks
+        for (auto chunk_id : chunks) {
+            chunk_clocks_[chunk_id] = clock;
+        }
+        
+        return clock;
+    }
+
+    int clock_ = 0;
+    int staleness_ = 1;
+    std::vector<int> chunk_clocks_;
+    kvstore::RangeManager* range_manager_ = nullptr;
+};
+
+}  // namespace model
+}  // namespace ml

--- a/ml/model/model_with_cm.hpp
+++ b/ml/model/model_with_cm.hpp
@@ -245,7 +245,6 @@ class ModelWithCM : public ChunkBasedMTLockModel {
     }
 
     virtual void replace_lock(int num_to_replace, std::vector<size_t>& chunks_to_replace) {}
-    virtual void touch(const std::vector<size_t>& chunks) {} // TODO remove
     virtual void touch(size_t chunk_id) {}
 
     boost::mutex global_mtx_;
@@ -353,7 +352,6 @@ class ModelWithCMLFU : public ModelWithCM {
         }
     }
 
-
     inline void touch(size_t chunk_id) override { frequency_[chunk_id] += 1; }
 
     std::vector<int> frequency_;
@@ -384,8 +382,6 @@ class ModelWithCMRandom : public ModelWithCM {
             }
         }
     }
-
-    inline void touch(const std::vector<size_t>& chunks) override {}
 };
 
 }  // namespace model

--- a/worker/instance_runner.cpp
+++ b/worker/instance_runner.cpp
@@ -26,9 +26,20 @@ Info InstanceRunner::info_factory(const std::shared_ptr<Instance>& instance, std
         
         try {
             if (hint.at(husky::constants::kType) == husky::constants::kPS) {
-                if (hint.find(husky::constants::kWorkerType) != hint.end()
-                    && hint.at(husky::constants::kWorkerType) == husky::constants::kSSPWorker) {
-                    info.set_mlworker(new ml::mlworker::SSPWorker(info));
+                if (hint.find(husky::constants::kWorkerType) != hint.end()) {
+                    if (hint.at(husky::constants::kWorkerType) == husky::constants::kSSPWorker) {
+                        husky::LOG_I << "using SSPWorker";
+                        info.set_mlworker(new ml::mlworker::SSPWorker(info));
+                    } else if (hint.at(husky::constants::kWorkerType) == husky::constants::kPSSharedWorkerChunk) {
+                        husky::LOG_I << "using PSSharedChunkWorker";
+                        info.set_mlworker(new ml::mlworker::PSSharedChunkWorker(info, cluster_manager_connector_.get_context()));
+                    } else if (hint.at(husky::constants::kWorkerType) == husky::constants::kSSPWorkerChunk) {
+                        husky::LOG_I << "using SSPWorkerChunk";
+                        info.set_mlworker(new ml::mlworker::SSPWorkerChunk(info));
+                    } else if (hint.at(husky::constants::kWorkerType) == husky::constants::kPSSharedWorker) {
+                        husky::LOG_I << "using PSSharedWorker";
+                        info.set_mlworker(new ml::mlworker::PSSharedWorker(info, cluster_manager_connector_.get_context()));
+                    } 
                 } else {
                     info.set_mlworker(new ml::mlworker::PSWorker(info));
                 }


### PR DESCRIPTION
1. For SSPWorker, now we provide 4 variants:
- SSPWorker (the original one)
- PSSharedWorker (with process cache)
- SSPWorkerChunk (chunk-based local model: ChunkBasedModelWithClocks)
- PSSharedChunkWorker (chunk-based local model with process cache)

2. One note: the stale chunks are not removed. For saving memory, may set a interval or threshold to remove stale chunks.