### PR TITLE
[lib|examples] modify AsyncReadBuffer and LRSampleReader

### DIFF
--- a/core/task.hpp
+++ b/core/task.hpp
@@ -119,13 +119,13 @@ class MLTask : public Task {
  * ConfigurableWorkersTask Task
  *
  */
-class ConfigurableWorkersTask : public Task {
+class ConfigurableWorkersTask : public MLTask {
    public:
     // For serialization usage only
     ConfigurableWorkersTask() = default;
-    ConfigurableWorkersTask(int id) : Task(id, Type::ConfigurableWorkersTaskType) {}
+    ConfigurableWorkersTask(int id) : MLTask(id) { type_ = Type::ConfigurableWorkersTaskType; }
     ConfigurableWorkersTask(int id, int total_epoch, int num_workers)
-        : Task(id, total_epoch, num_workers, Type::ConfigurableWorkersTaskType) {}
+        : MLTask(id, total_epoch, num_workers, Type::ConfigurableWorkersTaskType) {}
 
     void set_worker_num(const std::vector<int>& worker_num) { worker_num_ = worker_num; }
     void set_worker_num_type(const std::vector<std::string>& worker_num_type) { worker_num_type_ = worker_num_type; }
@@ -134,11 +134,11 @@ class ConfigurableWorkersTask : public Task {
     std::vector<std::string> get_worker_num_type() const { return worker_num_type_; }
 
     virtual BinStream& serialize(BinStream& bin) const {
-        Task::serialize(bin);
+        MLTask::serialize(bin);
         return bin << worker_num_ << worker_num_type_;
     }
     virtual BinStream& deserialize(BinStream& bin) {
-        Task::deserialize(bin);
+        MLTask::deserialize(bin);
         return bin >> worker_num_ >> worker_num_type_;
     }
     friend BinStream& operator<<(BinStream& bin, const ConfigurableWorkersTask& task) { return task.serialize(bin); }

--- a/lib/sample_reader.hpp
+++ b/lib/sample_reader.hpp
@@ -36,7 +36,7 @@ class AsyncReadBuffer final {
         batch_num_ = 0;
         load_cv_.notify_all();
         get_cv_.notify_all();
-        thread_.join();
+        if (thread_.joinable()) thread_.join();
     }
 
     /*


### PR DESCRIPTION
1. fix bug in destructor of AsyncReadBuffer
2. use configurable task in LRSampleReader to traverse cluster to test Single